### PR TITLE
bypassed the regex for certificate numbers when using the api

### DIFF
--- a/src/server/admin/enterCertificateNumber/controller.test.js
+++ b/src/server/admin/enterCertificateNumber/controller.test.js
@@ -1,6 +1,5 @@
 import { createServer } from '~/src/server/index.js'
 import * as yarHelpers from '~/src/server/common/helpers/yar-helper.js'
-import * as certHelpers from '../../common/helpers/certificates.js'
 
 describe('#enterCerficateNumberController', () => {
   /** @type {Server} */
@@ -81,34 +80,6 @@ describe('#enterCerficateNumberController', () => {
     })
 
     expect(payload).toContain('The certificate number cannot be empty')
-    expect(statusCode).toBe(400)
-  })
-
-  test('Should throw an error if certificate number is duplicate', async () => {
-    jest.spyOn(yarHelpers, 'setYarValue')
-    jest.spyOn(certHelpers, 'getList').mockResolvedValue([
-      {
-        certNumber: 'GBR-2024-CC-E56825BED',
-        timestamp: '2024-08-07T00:00:00.000Z',
-        status: 'COMPLETE'
-      }
-    ])
-    const { statusCode, payload } = await server.inject({
-      method: 'POST',
-      url: '/admin/enter-certificate-number',
-      auth: {
-        strategy: 'session-auth',
-        credentials: {
-          username: 'test',
-          password: 'test'
-        }
-      },
-      payload: {
-        certNumber: 'GBR-2024-CC-E56825BED'
-      }
-    })
-
-    expect(payload).toContain('The certificate number already exists')
     expect(statusCode).toBe(400)
   })
 })

--- a/src/server/admin/enterCertificateNumber/index.js
+++ b/src/server/admin/enterCertificateNumber/index.js
@@ -3,7 +3,6 @@ import {
   setYarValue,
   getYarValue
 } from '~/src/server/common/helpers/yar-helper.js'
-import { getList } from '../../common/helpers/certificates.js'
 
 /**
  * Sets up the routes used in the /admin/enter-certificate-number page.
@@ -19,14 +18,8 @@ export const enterCertificateNumberRoutes = [
   {
     method: 'POST',
     path: '/admin/enter-certificate-number',
-    handler: async (request, h) => {
-      const list = await getList(request)
-      if (
-        request.payload.certNumber === '' ||
-        list.find(
-          (listItem) => listItem.certNumber === request.payload.certNumber
-        )
-      ) {
+    handler: (request, h) => {
+      if (request.payload.certNumber === '') {
         const badRequestStatusCode = 400
         return h
           .view('admin/enterCertificateNumber/index', {
@@ -43,10 +36,7 @@ export const enterCertificateNumberRoutes = [
             certNumber: request.payload.certNumber,
             timestamp: getYarValue(request, 'timestamp'),
             status: getYarValue(request, 'status'),
-            errorMessage:
-              request.payload.certNumber === ''
-                ? 'The certificate number cannot be empty'
-                : 'The certificate number already exists'
+            errorMessage: 'The certificate number cannot be empty'
           })
           .code(badRequestStatusCode)
       }

--- a/src/server/certificates/controller.js
+++ b/src/server/certificates/controller.js
@@ -55,7 +55,7 @@ export const getCertificates = {
 export const updateCertificateDetails = {
   async handler(request, h) {
     const payload = request.payload
-    const result = await uploadCertificateDetails(request, payload)
+    const result = await uploadCertificateDetails(request, payload, true)
     if (result.error) {
       return h
         .response(

--- a/src/server/common/helpers/certificates.js
+++ b/src/server/common/helpers/certificates.js
@@ -62,11 +62,9 @@ export const uploadCertificateDetails = async (
   }
 
   let newCertificateList = []
-  const isCertificateNumberValid = checkCertificateNumber(
-    newCertificate.certNumber
-  )
+  const isAdminCertificate = checkCertificateNumber(newCertificate.certNumber)
 
-  if (isCertificateNumberValid ?? bypassRegex) {
+  if (isAdminCertificate === true || bypassRegex === true) {
     if (newCertificate.status === 'VOID') {
       const existingCertificate = list.find(
         (certificates) => certificates.certNumber === newCertificate.certNumber

--- a/src/server/common/helpers/certificates.js
+++ b/src/server/common/helpers/certificates.js
@@ -41,7 +41,16 @@ export const getList = async (request) => {
   return await download(request.s3, BUCKET_FILENAME)
 }
 
-export const uploadCertificateDetails = async (request, newCertificate) => {
+const checkCertificateNumber = (certNumber) => {
+  const matches = /GBR-\d{4}-(CM|PM|SM)/g.exec(certNumber)
+  return matches && matches.length > 0 ? true : null
+}
+
+export const uploadCertificateDetails = async (
+  request,
+  newCertificate,
+  bypassRegex = false
+) => {
   const logger = createLogger()
   const list = await getList(request)
 
@@ -53,9 +62,11 @@ export const uploadCertificateDetails = async (request, newCertificate) => {
   }
 
   let newCertificateList = []
-  const regex = /GBR-\d{4}-(CM|PM|SM)/g
-  const matches = regex.exec(newCertificate.certNumber)
-  if (matches && matches.length > 0) {
+  const isCertificateNumberValid = checkCertificateNumber(
+    newCertificate.certNumber
+  )
+
+  if (isCertificateNumberValid ?? bypassRegex) {
     if (newCertificate.status === 'VOID') {
       const existingCertificate = list.find(
         (certificates) => certificates.certNumber === newCertificate.certNumber

--- a/src/server/common/helpers/certificates.test.js
+++ b/src/server/common/helpers/certificates.test.js
@@ -239,7 +239,7 @@ describe('#certificates - upload', () => {
     )
   })
 
-  test('Should return false if there was no timestamp', async () => {
+  test('Should return an error if there was no timestamp', async () => {
     const request = {
       s3: jest.fn()
     }
@@ -255,7 +255,7 @@ describe('#certificates - upload', () => {
     })
   })
 
-  test('Should return false if there was no certNumber', async () => {
+  test('Should return an error if there was no certNumber', async () => {
     const request = {
       s3: jest.fn()
     }
@@ -320,6 +320,44 @@ describe('#certificates - upload', () => {
     expect(response).toStrictEqual({
       error: CERTIFICATE_NOT_FROM_ADMIN_APP
     })
+  })
+
+  test('Should upload a certificate with the wrong format if it is comming from the external endpoint', async () => {
+    const request = {
+      s3: jest.fn()
+    }
+    const updatedCertifiateJson = [
+      {
+        certNumber: 'GBR-2024-CC-123A4AW45',
+        status: 'COMPLETE',
+        timestamp: '2024-05-06T00:00:00.000Z'
+      },
+      {
+        certNumber: 'GBR-2024-CM-123A4AW06',
+        status: 'COMPLETE',
+        timestamp: '2024-05-06T00:00:00.000Z'
+      },
+      {
+        certNumber: 'GBR-2024-CM-123A4AW03',
+        status: 'DRAFT',
+        timestamp: '2024-07-06T00:00:00.000Z'
+      }
+    ]
+    jest.spyOn(S3Helpers, 'download').mockResolvedValue(certifiateJson)
+    jest.spyOn(S3Helpers, 'upload').mockResolvedValue(true)
+    await uploadCertificateDetails(
+      request,
+      {
+        certNumber: 'GBR-2024-CC-123A4AW45',
+        status: 'COMPLETE',
+        timestamp: '2024-05-06T00:00:00.000Z'
+      },
+      true
+    )
+    expect(S3Helpers.upload.mock.calls[0][1]).toBe('ecert_certificates.json')
+    expect(S3Helpers.upload.mock.calls[0][2]).toStrictEqual(
+      JSON.stringify(updatedCertifiateJson)
+    )
   })
 
   test('Should VOID a certificate', async () => {


### PR DESCRIPTION
Added a bypass for the regex on upload so that the external API can upload certificates that were not authored by the internal admin app

Removed check on enter certificate number page as it would stop users voiding an existing certificate