### PR TITLE
expose new endpoint and payload having list of certificates

### DIFF
--- a/src/server/certificates/controller.js
+++ b/src/server/certificates/controller.js
@@ -4,6 +4,7 @@ import {
   removeDocument,
   getList
 } from '../common/helpers/certificates.js'
+import { bulkUploadCertificateDetails } from '../common/helpers/bulk-upload.js'
 
 /**
  * A certificates check endpoint. Used by the platform to check if the provided certificates exists.
@@ -70,6 +71,23 @@ export const updateCertificateDetails = {
         .code(400)
     } else {
       return h.response(`Success`)
+    }
+  }
+}
+
+export const updateCertificatesDetails = {
+  async handler(request, h) {
+    const payload = request.payload
+    try {
+      await bulkUploadCertificateDetails(request, payload)
+      return h.response(`Success`)
+    } catch (e) {
+      return h
+        .response(
+          `
+          Error bulk updating certificate ${e}`
+        )
+        .code(500)
     }
   }
 }

--- a/src/server/certificates/controller.js
+++ b/src/server/certificates/controller.js
@@ -82,12 +82,13 @@ export const updateCertificatesDetails = {
       await bulkUploadCertificateDetails(request, payload)
       return h.response(`Success`)
     } catch (e) {
+      const errorCode500 = 500
       return h
         .response(
           `
           Error bulk updating certificate ${e}`
         )
-        .code(500)
+        .code(errorCode500)
     }
   }
 }

--- a/src/server/certificates/index.js
+++ b/src/server/certificates/index.js
@@ -2,6 +2,7 @@ import Joi from 'joi'
 import {
   certificatesController,
   updateCertificateDetails,
+  updateCertificatesDetails,
   removeCertificateDetails,
   getCertificates,
   validateCertificate
@@ -104,6 +105,27 @@ export const certificates = {
               timestamp: timestampJoi,
               status: Joi.string().example('COMPLETE')
             }).label('Paylod')
+          }
+        }
+      })
+
+      server.route({
+        method: 'PUT',
+        path: '/api/certificates',
+        options: {
+          ...updateCertificatesDetails,
+          auth: apiKeyAuthStrategy,
+          description: 'Include details of Export Certificates',
+          notes: 'The Certificate Numbers to include',
+          plugins: {
+            'hapi-swagger': {
+              responses: httpStatuses,
+              id: 'includeCertificateDetails'
+            }
+          },
+          tags: apiTags,
+          validate: {
+            payload: Joi.array()
           }
         }
       })

--- a/src/server/common/helpers/bulk-upload.js
+++ b/src/server/common/helpers/bulk-upload.js
@@ -18,13 +18,13 @@ export const bulkUploadCertificateDetails = async (
         ...newCertificate,
         status: 'COMPLETE'
       }
-      const result = await uploadCertificateDetails(
+      const res = await uploadCertificateDetails(
         request,
         completeCertificate,
         true
       )
-      if (result.error) {
-        logger.error(`Error: ${newCertificate.certNumber} ${result.error}`)
+      if (res.error) {
+        logger.error(`Error: ${newCertificate.certNumber} ${res.error}`)
         continue
       }
     }

--- a/src/server/common/helpers/bulk-upload.js
+++ b/src/server/common/helpers/bulk-upload.js
@@ -1,0 +1,40 @@
+import { uploadCertificateDetails } from './certificates.js'
+import { createLogger } from '~/src/server/common/helpers/logging/logger.js'
+
+export const bulkUploadCertificateDetails = async (
+  request,
+  certificateList
+) => {
+  const logger = createLogger()
+
+  for (const newCertificate of certificateList) {
+    logger.info(`
+      updating ${newCertificate.certNumber} with ${newCertificate.status} status`)
+
+    if (newCertificate.status === 'VOID') {
+      logger.info(`adding COMPLETE entry for ${newCertificate.certNumber}`)
+
+      const completeCertificate = {
+        ...newCertificate,
+        status: 'COMPLETE'
+      }
+      const result = await uploadCertificateDetails(
+        request,
+        completeCertificate,
+        true
+      )
+      if (result.error) {
+        logger.error(`Error: ${newCertificate.certNumber} ${result.error}`)
+        continue
+      }
+    }
+
+    logger.info(`
+      adding ${newCertificate.status} entry for ${newCertificate.certNumber}`)
+
+    const result = await uploadCertificateDetails(request, newCertificate, true)
+    if (result.error) {
+      logger.error(`Error: ${newCertificate.certNumber} ${result.error}`)
+    }
+  }
+}

--- a/src/server/common/helpers/bulk-upload.test.js
+++ b/src/server/common/helpers/bulk-upload.test.js
@@ -1,0 +1,121 @@
+import * as Certificate from '~/src/server/common/helpers/certificates.js'
+import * as loggerFunc from '~/src/server/common/helpers/logging/logger.js'
+import { bulkUploadCertificateDetails } from './bulk-upload.js'
+
+describe('#certificates - bulk upload', () => {
+  const request = {
+    s3: jest.fn()
+  }
+  const errorMock = jest.fn()
+  const infoMock = jest.fn()
+
+  let mockUploadCertificateDetails
+
+  beforeEach(() => {
+    mockUploadCertificateDetails = jest.spyOn(
+      Certificate,
+      'uploadCertificateDetails'
+    )
+    mockUploadCertificateDetails.mockResolvedValue(true)
+    jest.spyOn(loggerFunc, 'createLogger').mockReturnValue({
+      error: errorMock,
+      info: infoMock
+    })
+  })
+
+  afterEach(() => {
+    mockUploadCertificateDetails.mockRestore()
+    errorMock.mockRestore()
+    infoMock.mockRestore()
+  })
+
+  test('Should bulk upload with no errors', async () => {
+    const certificateList = [
+      {
+        certNumber: 'GBR-2024-CC-123A4AW06',
+        status: 'COMPLETE',
+        timestamp: '2024-05-06T00:00:00.000Z'
+      },
+      {
+        certNumber: 'GBR-2024-CC-123A4AW07',
+        status: 'COMPLETE',
+        timestamp: '2024-05-06T00:00:00.000Z'
+      }
+    ]
+
+    await bulkUploadCertificateDetails(request, certificateList)
+    expect(mockUploadCertificateDetails).toHaveBeenCalledTimes(2)
+  })
+
+  test('Should bulk upload with a VOID', async () => {
+    const certificateList = [
+      {
+        certNumber: 'GBR-2024-CC-123A4AW06',
+        status: 'COMPLETE',
+        timestamp: '2024-05-06T00:00:00.000Z'
+      },
+      {
+        certNumber: 'GBR-2024-CC-123A4AW07',
+        status: 'VOID',
+        timestamp: '2024-05-06T00:00:00.000Z'
+      }
+    ]
+
+    await bulkUploadCertificateDetails(request, certificateList)
+    expect(mockUploadCertificateDetails).toHaveBeenCalledTimes(3)
+  })
+
+  test('Should bulk upload with a VOID error', async () => {
+    mockUploadCertificateDetails.mockResolvedValueOnce({
+      error: 'CERTIFICATE_TO_VOID_NOT_FOUND'
+    })
+
+    mockUploadCertificateDetails.mockResolvedValue(true)
+
+    const certificateList = [
+      {
+        certNumber: 'GBR-2024-CC-123A4AW07',
+        status: 'VOID',
+        timestamp: '2024-05-06T00:00:00.000Z'
+      },
+      {
+        certNumber: 'GBR-2024-CC-123A4AW06',
+        status: 'COMPLETE',
+        timestamp: '2024-05-06T00:00:00.000Z'
+      }
+    ]
+
+    await bulkUploadCertificateDetails(request, certificateList)
+    expect(mockUploadCertificateDetails).toHaveBeenCalledTimes(2)
+  })
+
+  test('Should bulk upload with a COMPLETE error', async () => {
+    mockUploadCertificateDetails.mockResolvedValueOnce(true)
+    mockUploadCertificateDetails.mockResolvedValue({
+      error: 'CERTNUMBER_TIMESTAMP_MISSING'
+    })
+
+    const certificateList = [
+      {
+        certNumber: 'GBR-2024-CC-123A4AW07',
+        status: 'VOID',
+        timestamp: '2024-05-06T00:00:00.000Z'
+      },
+      {
+        certNumber: 'GBR-2024-CC-123A4AW06',
+        status: 'COMPLETE'
+      },
+      {
+        certNumber: 'GBR-2024-CC-123A4AW07',
+        status: 'COMPLETE',
+        timestamp: '2024-05-06T00:00:00.000Z'
+      }
+    ]
+
+    await bulkUploadCertificateDetails(request, certificateList)
+    expect(mockUploadCertificateDetails).toHaveBeenCalledTimes(4)
+    expect(errorMock).toHaveBeenCalledWith(
+      'Error: GBR-2024-CC-123A4AW06 CERTNUMBER_TIMESTAMP_MISSING'
+    )
+  })
+})


### PR DESCRIPTION
BCP app will expose a new endpoint called `/api/certificates` and as payload it will have a list of certificates:
```ts
[{
  certNumber: certNumberJoi,
  timestamp: timestampJoi,
  status: Joi.string().example('COMPLETE|VOID')
}]
```
add to the S3 json files all the certificates that has been passed in the payload