### PR TITLE
fix(auth): route Azure AD OIDC calls through CDP forward proxy

### DIFF
--- a/src/server/common/helpers/authentication/client.js
+++ b/src/server/common/helpers/authentication/client.js
@@ -1,12 +1,28 @@
-import { Issuer } from 'openid-client'
+import { Issuer, custom } from 'openid-client'
 import { config } from '~/src/config/index.js'
 import { createLogger } from '~/src/server/common/helpers/logging/logger.js'
+import { proxyAgent } from '~/src/server/common/helpers/proxy-agent.js'
 
 const logger = createLogger()
 
 Issuer.defaultHttpOptions = {
   timeout: 5000,
   retries: 2
+}
+
+/**
+ * Route openid-client's outbound HTTP calls (issuer discovery and token
+ * requests) through the CDP forward proxy when one is configured. In
+ * environments such as AWS Dev the containers have no direct egress, so
+ * without this the discovery call to login.microsoftonline.com fails with an
+ * AggregateError. Local dev has no proxy configured, so this is a no-op there.
+ */
+function configureProxy() {
+  const proxy = proxyAgent()
+  if (proxy) {
+    logger.info('Configuring Azure AD client to use forward proxy')
+    custom.setHttpOptionsDefaults({ agent: proxy.agent })
+  }
 }
 
 /**
@@ -36,6 +52,8 @@ class AuthenticationClient {
     }
 
     const discoveryUri = `https://login.microsoftonline.com/${tenantId}/.well-known/openid-configuration`
+
+    configureProxy()
 
     logger.info('Instantiating Azure AD issuer...')
 

--- a/src/server/common/helpers/authentication/client.test.js
+++ b/src/server/common/helpers/authentication/client.test.js
@@ -7,7 +7,8 @@ import {
   jest
 } from '@jest/globals'
 import AuthenticationClient from '~/src/server/common/helpers/authentication/client.js'
-import { Issuer } from 'openid-client'
+import { Issuer, custom } from 'openid-client'
+import { proxyAgent } from '~/src/server/common/helpers/proxy-agent.js'
 
 // Mock openid-client
 jest.mock('openid-client', () => {
@@ -25,10 +26,18 @@ jest.mock('openid-client', () => {
       discover: jest.fn(() => mockIssuer),
       defaultHttpOptions: {}
     },
+    custom: {
+      setHttpOptionsDefaults: jest.fn()
+    },
     __mockClient: mockClient,
     __mockIssuer: mockIssuer
   }
 })
+
+// Mock proxy agent
+jest.mock('~/src/server/common/helpers/proxy-agent.js', () => ({
+  proxyAgent: jest.fn(() => null)
+}))
 
 // Mock config
 jest.mock('~/src/config/index.js', () => ({
@@ -82,6 +91,27 @@ describe('AuthenticationClient', () => {
       const client2 = await AuthenticationClient.getClient()
 
       expect(client1).toBe(client2)
+      expect(Issuer.discover).toHaveBeenCalledTimes(1)
+    })
+
+    test('Should not configure a proxy when none is set (local dev)', async () => {
+      proxyAgent.mockReturnValueOnce(null)
+
+      await AuthenticationClient.getClient()
+
+      expect(custom.setHttpOptionsDefaults).not.toHaveBeenCalled()
+      expect(Issuer.discover).toHaveBeenCalledTimes(1)
+    })
+
+    test('Should configure openid-client to use the proxy when one is set', async () => {
+      const agent = { agent: 'mock-agent' }
+      proxyAgent.mockReturnValueOnce(agent)
+
+      await AuthenticationClient.getClient()
+
+      expect(custom.setHttpOptionsDefaults).toHaveBeenCalledWith({
+        agent: agent.agent
+      })
       expect(Issuer.discover).toHaveBeenCalledTimes(1)
     })
   })


### PR DESCRIPTION
### Description
The openid-client Issuer.discover() and token requests use their own internal HTTP layer and bypass the app's proxy configuration. In CDP environments (DEV/TEST/PERF/PROD) where containers have no direct egress, this caused the discovery call to login.microsoftonline.com to fail with an AggregateError (connection timeout) when a user clicked the admin link.

Configure openid-client's global HTTP options with the existing proxyAgent() helper so discovery and token calls route through CDP_HTTPS_PROXY/CDP_HTTP_PROXY, mirroring proxy-fetch.js. The proxy is only applied when configured, so local dev (no proxy) is unaffected.

Add test coverage for both proxy-configured and no-proxy paths.

Copilot-Assisted: true

### Jira Issue(s)
- [WEB-1-Missing Account Lockout Policy](https://eaflood.atlassian.net/browse/FI0-11024)
- [WEB-4-Missing Password Change Functionality](https://eaflood.atlassian.net/browse/FI0-11027)
